### PR TITLE
Fix disabling of pdf-keynav-mode when pdf-sync is not loaded

### DIFF
--- a/lisp/pdf-keynav.el
+++ b/lisp/pdf-keynav.el
@@ -574,8 +574,8 @@ necessary buffer-locals have been loaded."
 	'pdf-view-previous-line-or-previous-page)
       (define-key map (kbd "r") 'revert-buffer)
       (define-key map (kbd "m") 'pdf-view-position-to-register))
-    (let ((map pdf-sync-minor-mode-map))
-      (define-key map [double-mouse-1] 'pdf-sync-backward-search-mouse))
+    (when (boundp 'pdf-sync-minor-mode-map)
+      (define-key 'pdf-sync-minor-mode-map [double-mouse-1] 'pdf-sync-backward-search-mouse))
 
     ;; redisplay to remove region/point
     (pdf-view-redisplay)))


### PR DESCRIPTION
Missed this from my previous clean-ups.

A comment by the way:
I see why these unbindings and rebindings are needed, since there is no way to let the bindings of one minor-mode take precedence of those of another. However, unbinding the keys from other minor-mode maps is perhaps not ideal, since it changes how that mode behaves not only in the current buffer (where `pdf-keynav-mode` is activated) but in all buffers where that mode is active. It breaks the local/global assumptions of what activating a mode should do.